### PR TITLE
fix apps.* endpoints that require jwt_token

### DIFF
--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -182,9 +182,11 @@
    "source": [
     "#export\n",
     "class GhApi(_GhObj):\n",
-    "    def __init__(self, owner=None, repo=None, token=None, debug=None, limit_cb=None, **kwargs):\n",
+    "    def __init__(self, owner=None, repo=None, token=None, jwt_token=None, debug=None, limit_cb=None, **kwargs):\n",
     "        self.headers = { 'Accept': 'application/vnd.github.v3+json' }\n",
     "        token = token or os.getenv('GITHUB_TOKEN', None)\n",
+    "        jwt_token = jwt_token or os.getenv('GITHUB_JWT_TOKEN', None)\n",
+    "        if jwt_token: self.headers['Authorization'] = 'Bearer ' + jwt_token\n",
     "        if token: self.headers['Authorization'] = 'token ' + token\n",
     "        if owner: kwargs['owner'] = owner\n",
     "        if repo:  kwargs['repo' ] = repo\n",

--- a/ghapi/core.py
+++ b/ghapi/core.py
@@ -87,9 +87,11 @@ _docroot = 'https://docs.github.com/en/free-pro-team@latest/rest/reference/'
 
 # Cell
 class GhApi(_GhObj):
-    def __init__(self, owner=None, repo=None, token=None, debug=None, limit_cb=None, **kwargs):
+    def __init__(self, owner=None, repo=None, token=None, jwt_token=None, debug=None, limit_cb=None, **kwargs):
         self.headers = { 'Accept': 'application/vnd.github.v3+json' }
         token = token or os.getenv('GITHUB_TOKEN', None)
+        jwt_token = jwt_token or os.getenv('GITHUB_JWT_TOKEN', None)
+        if jwt_token: self.headers['Authorization'] = 'Bearer ' + jwt_token
         if token: self.headers['Authorization'] = 'token ' + token
         if owner: kwargs['owner'] = owner
         if repo:  kwargs['repo' ] = repo


### PR DESCRIPTION
Adds `jwt_token` attribute to `GhApi` to allow users to call app endpoints that require a jwt token instead of a  pat/access_key

closes #85 

This should fix and allow you to authenticate to the following endpoints:

- apps.get_authenticated(): Get the authenticated app
- apps.list_installations(per_page, page, since, outdated): List installations for the authenticated app
- apps.get_installation(installation_id): Get an installation for the authenticated app
- apps.delete_installation(installation_id): Delete an installation for the authenticated app
- apps.create_installation_access_token(installation_id, repositories, repository_ids, permissions): Create an installation access token for an app
- apps.suspend_installation(installation_id): Suspend an app installation
- apps.unsuspend_installation(installation_id): Unsuspend an app installation
- apps.get_org_installation(org): Get an organization installation for the authenticated app
- apps.get_repo_installation(owner, repo): Get a repository installation for the authenticated app
- apps.get_user_installation(username): Get a user installation for the authenticated app
- apps.get_webhook_config_for_app(): Get a webhook configuration for an app
- apps.update_webhook_config_for_app(url, content_type, secret, insecure_ssl): Update a webhook configuration for an app
- apps.get_subscription_plan_for_account_stubbed(account_id): Get a subscription plan for an account (stubbed)
- apps.list_plans_stubbed(per_page, page): List plans (stubbed)
- apps.list_accounts_for_plan_stubbed(plan_id, sort, direction, per_page, page): List accounts for a plan (stubbed)

And probably more, these were just the ones I quickly tested.

For example:

```python
jwt = create_jwt(app_id, private_key)

app_api = GhApi(jwt_token=jwt)

print("List Installations")
installations = app_api.apps.list_installations()
print(installations)

print("Get Access Token")
id = installations[0]['id']
print(app_api.apps.create_installation_access_token(id))
```

```
List Installations

[- id: 1111
- account: 
  - login: ffalor
  - id: 1
  - node_id: MDQ6VXNlcjM1MTQ0MTQx
  #etc...]

Get Access Token
- token: ghs_324324234234
- expires_at: 2021-08-21T11:40:36Z
- permissions: 
  - administration: read
  - contents: read
  - issues: write
  - metadata: read
- repository_selection: all
```

Not 100% what all I can update since from my understanding this project is auto generated. I did not see any tests to update. Please let me know what would need to change in order to add the ability to provide a jwt_token.

Reopen of #87 had to fix line ending changes and auto formatting.