### PR TITLE
feat(actions): add notice message function

### DIFF
--- a/docs/actions.html
+++ b/docs/actions.html
@@ -744,7 +744,46 @@ steps:
 
 
 <div class="output_markdown rendered_html output_subarea ">
-<h4 id="actions_warn" class="doc_header"><code>actions_warn</code><a href="https://github.com/fastai/ghapi/tree/master/ghapi/actions.py#L131" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>actions_warn</code>(<strong><code>message</code></strong>, <strong><code>details</code></strong>=<em><code>''</code></em>)</p>
+<h4 id="actions_notice" class="doc_header"><code>actions_notice</code><a href="https://github.com/fastai/ghapi/tree/master/ghapi/actions.py#L131" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>actions_notice</code>(<strong><code>message</code></strong>, <strong><code>details</code></strong>=<em><code>''</code></em>)</p>
+</blockquote>
+<p>Print the special <code>::notice</code> line for <code>message</code></p>
+
+</div>
+
+</div>
+
+</div>
+</div>
+
+</div>
+    {% endraw %}
+
+    {% raw %}
+    
+<div class="cell border-box-sizing code_cell rendered">
+
+</div>
+    {% endraw %}
+
+<div class="cell border-box-sizing text_cell rendered"><div class="inner_cell">
+<div class="text_cell_render border-box-sizing rendered_html">
+<p>Details in the <a href="https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#setting-a-notice-message">GitHub Documentation for <code>notice</code></a>. For the optional <code>details</code>, you can provide comma-delimited file, line, and column information, e.g.: <code>file=app.js,line=1,col=5</code>.</p>
+
+</div>
+</div>
+</div>
+    {% raw %}
+    
+<div class="cell border-box-sizing code_cell rendered">
+
+<div class="output_wrapper">
+<div class="output">
+
+<div class="output_area">
+
+
+<div class="output_markdown rendered_html output_subarea ">
+<h4 id="actions_warn" class="doc_header"><code>actions_warn</code><a href="https://github.com/fastai/ghapi/tree/master/ghapi/actions.py#L136" class="source_link" style="float:right">[source]</a></h4><blockquote><p><code>actions_warn</code>(<strong><code>message</code></strong>, <strong><code>details</code></strong>=<em><code>''</code></em>)</p>
 </blockquote>
 <p>Print the special <code>::warning</code> line for <code>message</code></p>
 

--- a/ghapi/actions.py
+++ b/ghapi/actions.py
@@ -3,8 +3,8 @@
 __all__ = ['contexts', 'context_github', 'context_env', 'context_job', 'context_steps', 'context_runner',
            'context_secrets', 'context_strategy', 'context_matrix', 'context_needs', 'env_github', 'user_repo', 'Event',
            'create_workflow_files', 'fill_workflow_templates', 'env_contexts', 'def_pipinst', 'create_workflow',
-           'gh_create_workflow', 'example_payload', 'github_token', 'actions_output', 'actions_debug', 'actions_warn',
-           'actions_error', 'actions_group', 'actions_mask', 'set_git_user']
+           'gh_create_workflow', 'example_payload', 'github_token', 'actions_output', 'actions_debug', 'actions_notice',
+           'actions_warn', 'actions_error', 'actions_group', 'actions_mask', 'set_git_user']
 
 # Cell
 from fastcore.utils import *
@@ -126,6 +126,11 @@ def actions_output(name, value):
 def actions_debug(message):
     "Print the special `::debug` line for `message`"
     print(f"::debug::{message}")
+
+# Cell
+def actions_warn(message, details=''):
+    "Print the special `::notice` line for `message`"
+    print(f"::notice {details}::{message}")
 
 # Cell
 def actions_warn(message, details=''):


### PR DESCRIPTION
Since https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-a-notice-message was missing.