### PR TITLE
Remove the check which removes `None` values

### DIFF
--- a/00_core.ipynb
+++ b/00_core.ipynb
@@ -115,7 +115,6 @@
     "        d = list(self.data)\n",
     "        flds = [o for o in self.route_ps+self.params+d if o not in kwargs]\n",
     "        for a,b in zip(args,flds): kwargs[b]=a\n",
-    "        kwargs = {k:v for k,v in kwargs.items() if v is not None}\n",
     "        route_p,query_p,data_p = [{p:kwargs[p] for p in o if p in kwargs}\n",
     "                                 for o in (self.route_ps,self.params,d)]\n",
     "        return self.client(self.path, self.verb, headers=headers, route=route_p, query=query_p, data=data_p)\n",

--- a/ghapi/core.py
+++ b/ghapi/core.py
@@ -56,7 +56,6 @@ class _GhVerb(_GhObj):
         d = list(self.data)
         flds = [o for o in self.route_ps+self.params+d if o not in kwargs]
         for a,b in zip(args,flds): kwargs[b]=a
-        kwargs = {k:v for k,v in kwargs.items() if v is not None}
         route_p,query_p,data_p = [{p:kwargs[p] for p in o if p in kwargs}
                                  for o in (self.route_ps,self.params,d)]
         return self.client(self.path, self.verb, headers=headers, route=route_p, query=query_p, data=data_p)


### PR DESCRIPTION
`None` (`null`) is a valid value for several GitHub API endpoints. This commit removes a line which strips these valid values from all requests.

(Credit to @reaganbarker for finding this https://github.com/fastai/ghapi/issues/81#issuecomment-1513788513)

Fixes #81 