### PR TITLE
Declare support for Python 3.13 and 3.14

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ licenses = {
 }
 statuses = [ '1 - Planning', '2 - Pre-Alpha', '3 - Alpha',
     '4 - Beta', '5 - Production/Stable', '6 - Mature', '7 - Inactive' ]
-py_versions = '2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4 3.5 3.6 3.7 3.8 3.9 3.10 3.11 3.12'.split()
+py_versions = '2.0 2.1 2.2 2.3 2.4 2.5 2.6 2.7 3.0 3.1 3.2 3.3 3.4 3.5 3.6 3.7 3.8 3.9 3.10 3.11 3.12 3.13 3.14'.split()
 min_python = cfg['min_python']
 lic = licenses[cfg['license']]
 


### PR DESCRIPTION
Python 3.14 was released last month: https://devguide.python.org/versions/