### PR TITLE
Fixes missing dep: Add 'gql' dependency to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {text = "Apache-2.0"}
 authors = [{name = "Jeremy Howard", email = "info@fast.ai"}]
 keywords = ['github', 'api']
 classifiers = ["Natural Language :: English", "Intended Audience :: Developers", "Development Status :: 5 - Production/Stable", "Programming Language :: Python :: 3", "Programming Language :: Python :: 3 :: Only"]
-dependencies = ['fastcore>=1.12.19']
+dependencies = ['fastcore>=1.12.19', 'gql']
 
 [project.urls]
 Repository = "https://github.com/fastai/ghapi"


### PR DESCRIPTION
Fixes missing dep for ghapi.graphql module

<img width="729" height="307" alt="image" src="https://github.com/user-attachments/assets/c6215541-7332-4fb8-963d-968bfe82bc0e" />
